### PR TITLE
fix(main) emit error on redirect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -403,6 +403,10 @@ module.exports = function SitemapGenerator(uri, opts) {
     crawler.on('fetchprevented', ({
       url
     }) => emitError(403, url));
+    crawler.on('fetchredirect', ({url}) => {
+      emitError(301, url)
+      return;
+    })
 
     crawler.on('queueerror', ({
       url


### PR DESCRIPTION
Crawler should emit a 301 error when a link has a redirect. This helps SEO see what urls redirects and possibly investigate further