### PR TITLE
Eliminate lodash to clear unfixed v4 CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "crypto-random-string": "5.0.0",
     "follow-redirects": "^1.13.0",
     "https": "^1.0.0",
-    "lodash": "4.17.21",
     "mitt": "3.0.1",
     "node-translate": "0.0.4",
     "normalize-url": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -64,5 +64,5 @@
     "url": "git+https://github.com/hazemhagrass/advanced-sitemap-generator.git"
   },
   "scripts": {},
-  "version": "1.8.8"
+  "version": "1.8.9"
 }

--- a/src/createCrawler.js
+++ b/src/createCrawler.js
@@ -1,6 +1,5 @@
 const Crawler = require('simplecrawler');
 const URLParser = require('url');
-const has = require('lodash/has');
 
 const discoverResources = require('./discoverResources');
 const stringifyURL = require('./helpers/stringifyURL');
@@ -60,7 +59,7 @@ module.exports = (uri, options = {}, browser) => {
   const crawler = new Crawler(uri.href);
 
   Object.keys(options).forEach(o => {
-    if (has(crawler, o)) {
+    if (Object.prototype.hasOwnProperty.call(crawler, o)) {
       crawler[o] = options[o];
     } else if (o === 'crawlerMaxDepth') {
       // eslint-disable-next-line


### PR DESCRIPTION
| | |
|---|---|
| **GitHub Issue** | Relates to https://github.com/TodayTix/ttg/issues/15642 (sub-issue under Mythos GA hardening epic https://github.com/TodayTix/ttg/issues/15135) |
| **Problem** | lodash v4 has three unfixed CVEs (GHSA-r5fr-rjxr-66jc code injection, GHSA-xxjr-mmjv-4gpg + GHSA-f23m-r3pf-42rh prototype pollution). No v4 patch exists; v5 has no release date. Pinned at lodash@4.17.21 here, used in exactly one place: src/createCrawler.js calls lodash/has(crawler, o) to check whether an option key exists on the simplecrawler instance. |
| **Impact** | TodayTix/sitemap-generator carries a permanent High Dependabot alert as long as this package keeps lodash. Blocks the sitemap-generator sub-issue under the Mythos GA hardening epic. |
| **Outcome** | lodash is gone from dependencies. Downstream consumers regenerating their lockfile against this commit drop lodash from their tree entirely. Version bumped to 1.8.9 to mark the release. |

#### Context

lodash/has(obj, path) is documented as "checks if path is a direct property of object". For non-nested keys (the only usage here) that is identical to Object.prototype.hasOwnProperty.call(obj, key). Verified there are no other lodash references in src/.

#### Changes

- src/createCrawler.js — drop require('lodash/has'); replace has(crawler, o) with Object.prototype.hasOwnProperty.call(crawler, o).
- package.json — remove "lodash": "4.17.21" from dependencies; bump version 1.8.8 → 1.8.9.

#### Decisions

- Native equivalent over a smaller utility package (e.g. has-prop) — zero new transitive deps for a one-line check.
- Version bump as 1.8.9 (patch) rather than 2.0.0 (major) — public API is unchanged. Marker for downstream consumers.

#### How to verify

1. npm install completes cleanly.
2. In a consumer pointing at this branch ("github:TodayTix/sitemap-generator#security/drop-lodash"), npm install --package-lock-only produces a lockfile with no lodash entry.
3. End-to-end smoke: TodayTix/sitemapper qa-create-lt CircleCI workflow runs to completion against the merged commit.

🤖 This was posted by Claude