### PR TITLE
Fix invalid-date errors in generated sitemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "picomatch": "2.3.2",
     "underscore": "1.13.8"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "node --test src/"
+  },
   "version": "1.8.9"
 }

--- a/src/SitemapStream.js
+++ b/src/SitemapStream.js
@@ -61,7 +61,9 @@ module.exports = function SitemapStream(options) {
       stream.write(`\n    <changefreq>${options.changeFreq}</changefreq>`);
     }
     stream.write(`\n    <priority>${getPriorityFromDepth(queueItem.depth)}</priority>`);
-    stream.write(`\n    <lastmod>${queueItem.lastMod}</lastmod>`);
+    if (queueItem.lastMod) {
+      stream.write(`\n    <lastmod>${queueItem.lastMod}</lastmod>`);
+    }
     stream.write(`\n  </url>`);
   };
 

--- a/src/SitemapStream.test.js
+++ b/src/SitemapStream.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+
+const SitemapStream = require('./SitemapStream');
+
+// The write stream finishes asynchronously; poll until the closing tag lands.
+const readWhenFinalized = async filePath => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      if (content.includes('</urlset>')) {
+        return content;
+      }
+    } catch (err) {
+      // file not written yet
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('Sitemap was not finalized in time');
+};
+
+const buildQueueItem = overrides => ({
+  url: 'https://example.com/page',
+  depth: 1,
+  alternatives: [],
+  lastMod: '',
+  ...overrides,
+});
+
+test('includes <lastmod> when the URL has a date', async () => {
+  const sitemap = SitemapStream({});
+  sitemap.addURL(
+    buildQueueItem({ url: 'https://example.com/dated', lastMod: '2024-01-15' })
+  );
+  sitemap.flush();
+  sitemap.end();
+
+  const xml = await readWhenFinalized(sitemap.getPath());
+  assert.match(xml, /<loc>https:\/\/example\.com\/dated<\/loc>/);
+  assert.match(xml, /<lastmod>2024-01-15<\/lastmod>/);
+});
+
+test('omits <lastmod> entirely when the URL has no date', async () => {
+  const sitemap = SitemapStream({});
+  sitemap.addURL(
+    buildQueueItem({ url: 'https://example.com/undated', lastMod: '' })
+  );
+  sitemap.flush();
+  sitemap.end();
+
+  const xml = await readWhenFinalized(sitemap.getPath());
+  assert.match(xml, /<loc>https:\/\/example\.com\/undated<\/loc>/);
+  // An empty <lastmod></lastmod> is what Google rejects as "invalid date".
+  assert.doesNotMatch(xml, /<lastmod><\/lastmod>/);
+  // With no date, the optional tag should not be emitted at all.
+  assert.doesNotMatch(xml, /<lastmod>/);
+});


### PR DESCRIPTION
## What & why

Google Search Console has been flagging our sitemaps with errors. The reason: when the generator doesn't have a "last modified" date for a page, it still writes an empty date tag — and Search Console rejects an empty date as invalid.

It's most of each sitemap: New York Theatre Guide shows 14,397 of 20,599 URLs flagged, London Theatre 10,904 of 15,832. It doesn't stop those pages getting indexed, but it makes every sitemap look broken in Search Console and wastes the "freshness" signal Google uses to decide what to re-crawl.

## The change

Only write the date tag when we actually have a date; otherwise leave it out (the tag is optional). Pages we crawl still get their date exactly as before — pages without one simply omit the tag instead of sending a blank one.

## Result

Clears the "invalid date" errors across every site this generator builds (TodayTix, London Theatre, NYTG, Box Office), not just one.

## Testing

Added a test covering both cases: a URL with a date keeps its date tag; a URL without one no longer emits an empty tag. Run with `npm test`.

🤖 This was posted by Claude
